### PR TITLE
fix: Fix type error doing dryrun with fixed reference

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -41,7 +41,7 @@ mash_db = db_dir.joinpath("bacteria-refseq", "db.msh")
 referenceseeker_md5 = str(db_dir.joinpath("bacteria-refseq", "downloaded_db.txt"))
 
 if (config["dryrun"] is True) and (GIVEN_REF != "None"):
-    ref_genome = GIVEN_REF
+    ref_genome = Path(GIVEN_REF)
 else:
     ref_genome = output_dir.joinpath("ref_genomes_used", "cluster_1", "ref_genome.seq")
 


### PR DESCRIPTION
The type of the reference location was a str in stead of pathlib.Path when doing a dryrun in Snakefile. This is a very simple fix that should not affect any results other than when doing a dryrun.